### PR TITLE
bug: icb_session can be not set

### DIFF
--- a/iceberg.py
+++ b/iceberg.py
@@ -3895,5 +3895,6 @@ while True:
             
         
 icb_session.session_log_connection.close()
-icb_session.connection.close()
+if icb_session.connection:
+    icb_session.connection.close()
 icb_session.window.close()


### PR DESCRIPTION
- Closes #33 
- Check to see if `icb_session` is set, as it is initialized as `False`.  If it is not set, don't issue a close().